### PR TITLE
feat: expose metrics related to validators rank

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,13 +81,16 @@ GLOBAL OPTIONS:
 All metrics are by default prefixed by `cosmos_validator_watcher` but this can be changed through options.
 
 Metrics (without prefix) | Description
-----------------------------------------------|------------------------------------------------
+-------------------------|-------------------------------------------------------------------------
 `block_height`           | Latest known block height (all nodes mixed up)
+`active_set`             | Number of validators in the active set
+`seat_price`             | Min seat price to be in the active set (ie. bonded tokens of the latest validator)
+`rank`                   | Rank of the validator
 `validated_blocks`       | Number of validated blocks per validator (for a bonded validator)
 `missed_blocks`          | Number of missed blocks per validator (for a bonded validator)
 `tracked_blocks`         | Number of blocks tracked since start
 `skipped_blocks`         | Number of blocks skipped (ie. not tracked) since start
-`bonded_tokens`          | Number of bonded tokens per validator
+`tokens`                 | Number of staked tokens per validator
 `is_bonded`              | Set to 1 if the validator is bonded
 `is_jail`                | Set to 1 if the validator is jailed
 `node_block_height`      | Latest fetched block height for each node

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -5,11 +5,14 @@ import "github.com/prometheus/client_golang/prometheus"
 type Metrics struct {
 	// Exporter metrics
 	BlockHeight     prometheus.Gauge
+	Rank            *prometheus.GaugeVec
+	ActiveSet       prometheus.Gauge
+	SeatPrice       prometheus.Gauge
 	ValidatedBlocks *prometheus.CounterVec
 	MissedBlocks    *prometheus.CounterVec
 	TrackedBlocks   prometheus.Counter
 	SkippedBlocks   prometheus.Counter
-	BondedTokens    *prometheus.GaugeVec
+	Tokens          *prometheus.GaugeVec
 	IsBonded        *prometheus.GaugeVec
 	IsJailed        *prometheus.GaugeVec
 
@@ -26,6 +29,28 @@ func New(namespace string) *Metrics {
 				Name:      "block_height",
 				Help:      "Latest known block height (all nodes mixed up)",
 			},
+		),
+		ActiveSet: prometheus.NewGauge(
+			prometheus.GaugeOpts{
+				Namespace: namespace,
+				Name:      "active_set",
+				Help:      "Number of validators in the active set",
+			},
+		),
+		SeatPrice: prometheus.NewGauge(
+			prometheus.GaugeOpts{
+				Namespace: namespace,
+				Name:      "seat_price",
+				Help:      "Min seat price to be in the active set (ie. bonded tokens of the latest validator)",
+			},
+		),
+		Rank: prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Namespace: namespace,
+				Name:      "rank",
+				Help:      "Rank of the validator",
+			},
+			[]string{"address", "name"},
 		),
 		ValidatedBlocks: prometheus.NewCounterVec(
 			prometheus.CounterOpts{
@@ -57,11 +82,11 @@ func New(namespace string) *Metrics {
 				Help:      "Number of blocks skipped (ie. not tracked) since start",
 			},
 		),
-		BondedTokens: prometheus.NewGaugeVec(
+		Tokens: prometheus.NewGaugeVec(
 			prometheus.GaugeOpts{
 				Namespace: namespace,
 				Name:      "bonded_tokens",
-				Help:      "Number of bonded tokens per validator",
+				Help:      "Number of staked tokens per validator",
 			},
 			[]string{"address", "name"},
 		),
@@ -100,11 +125,14 @@ func New(namespace string) *Metrics {
 	}
 
 	prometheus.MustRegister(metrics.BlockHeight)
+	prometheus.MustRegister(metrics.ActiveSet)
+	prometheus.MustRegister(metrics.SeatPrice)
+	prometheus.MustRegister(metrics.Rank)
 	prometheus.MustRegister(metrics.ValidatedBlocks)
 	prometheus.MustRegister(metrics.MissedBlocks)
 	prometheus.MustRegister(metrics.TrackedBlocks)
 	prometheus.MustRegister(metrics.SkippedBlocks)
-	prometheus.MustRegister(metrics.BondedTokens)
+	prometheus.MustRegister(metrics.Tokens)
 	prometheus.MustRegister(metrics.IsBonded)
 	prometheus.MustRegister(metrics.IsJailed)
 	prometheus.MustRegister(metrics.NodeBlockHeight)


### PR DESCRIPTION
added new metrics:
- `rank`
- `active_set`
- `seat_price`

renamed metric `bonded_tokens` to `token`

closes #8 