### PR TITLE
feat: check and export upgrade plan presence

### DIFF
--- a/pkg/app/flags.go
+++ b/pkg/app/flags.go
@@ -35,6 +35,10 @@ var Flags = []cli.Flag{
 		Name:  "no-staking",
 		Usage: "disable calls to staking module (useful for consumer chains)",
 	},
+	&cli.BoolFlag{
+		Name:  "no-upgrade",
+		Usage: "disable calls to upgrade module (useful for consumer chains)",
+	},
 	&cli.StringSliceFlag{
 		Name:  "validator",
 		Usage: "validator address(es) to track (use :my-label to add a custom label in metrics & ouput)",

--- a/pkg/app/run.go
+++ b/pkg/app/run.go
@@ -32,6 +32,7 @@ func RunFunc(cCtx *cli.Context) error {
 		noColor    = cCtx.Bool("no-color")
 		nodes      = cCtx.StringSlice("node")
 		noStaking  = cCtx.Bool("no-staking")
+		noUpgrade  = cCtx.Bool("no-upgrade")
 		validators = cCtx.StringSlice("validator")
 	)
 
@@ -125,6 +126,12 @@ func RunFunc(cCtx *cli.Context) error {
 		validatorsWatcher := watcher.NewValidatorsWatcher(trackedValidators, metrics, pool)
 		errg.Go(func() error {
 			return validatorsWatcher.Start(ctx)
+		})
+	}
+	if !noUpgrade {
+		upgradeWatcher := watcher.NewUpgradeWatcher(metrics, pool)
+		errg.Go(func() error {
+			return upgradeWatcher.Start(ctx)
 		})
 	}
 

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -16,6 +16,7 @@ type Metrics struct {
 	Tokens           *prometheus.GaugeVec
 	IsBonded         *prometheus.GaugeVec
 	IsJailed         *prometheus.GaugeVec
+	UpgradePlan      *prometheus.GaugeVec
 
 	// Node metrics
 	NodeBlockHeight *prometheus.GaugeVec
@@ -136,6 +137,14 @@ func New(namespace string) *Metrics {
 			},
 			[]string{"chain_id", "node"},
 		),
+		UpgradePlan: prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Namespace: namespace,
+				Name:      "upgrade_plan",
+				Help:      "Set to 1 if chain has an upgrade plan",
+			},
+			[]string{"chain_id"},
+		),
 	}
 
 	return metrics
@@ -156,4 +165,5 @@ func (m *Metrics) Register() {
 	prometheus.MustRegister(m.IsJailed)
 	prometheus.MustRegister(m.NodeBlockHeight)
 	prometheus.MustRegister(m.NodeSynced)
+	prometheus.MustRegister(m.UpgradePlan)
 }

--- a/pkg/watcher/upgrade.go
+++ b/pkg/watcher/upgrade.go
@@ -1,0 +1,66 @@
+package watcher
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/cosmos/cosmos-sdk/client"
+	upgrade "github.com/cosmos/cosmos-sdk/x/upgrade/types"
+	"github.com/kilnfi/cosmos-validator-watcher/pkg/metrics"
+	"github.com/kilnfi/cosmos-validator-watcher/pkg/rpc"
+	"github.com/rs/zerolog/log"
+)
+
+type UpgradeWatcher struct {
+	metrics *metrics.Metrics
+	pool    *rpc.Pool
+}
+
+func NewUpgradeWatcher(metrics *metrics.Metrics, pool *rpc.Pool) *UpgradeWatcher {
+	return &UpgradeWatcher{
+		metrics: metrics,
+		pool:    pool,
+	}
+}
+
+func (w *UpgradeWatcher) Start(ctx context.Context) error {
+	ticker := time.NewTicker(30 * time.Second)
+
+	for {
+		node := w.pool.GetSyncedNode()
+		if node == nil {
+			log.Warn().Msg("no node available to fetch updates")
+		} else if err := w.fetchUpdates(ctx, node); err != nil {
+			log.Error().Err(err).Msg("failed to fetch pending updates")
+		}
+
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-ticker.C:
+		}
+	}
+}
+
+func (w *UpgradeWatcher) fetchUpdates(ctx context.Context, node *rpc.Node) error {
+	clientCtx := (client.Context{}).WithClient(node.Client)
+	queryClient := upgrade.NewQueryClient(clientCtx)
+
+	// Fetch all proposals in voting period
+	planResp, err := queryClient.CurrentPlan(ctx, &upgrade.QueryCurrentPlanRequest{})
+	if err != nil {
+		return fmt.Errorf("failed to get plan: %w", err)
+	}
+
+	isPlan := false
+	if planResp.Plan != nil {
+		isPlan = true
+	}
+
+	w.metrics.UpgradePlan.
+		WithLabelValues(node.ChainID()).
+		Set(metrics.BoolToFloat64(isPlan))
+
+	return nil
+}


### PR DESCRIPTION
Tested manually.

cosmos_validator_watcher_upgrade_plan{chain_id="cosmoshub-4"} 0

cosmos_validator_watcher_upgrade_plan{chain_id="evmos_9001-2"} 1