### PR TITLE
fix: mark node without new block as not synced

### DIFF
--- a/pkg/rpc/node.go
+++ b/pkg/rpc/node.go
@@ -86,7 +86,8 @@ func (n *Node) IsSynced() bool {
 		return false
 	}
 
-	return !status.SyncInfo.CatchingUp
+	return !status.SyncInfo.CatchingUp &&
+		status.SyncInfo.LatestBlockTime.After(time.Now().Add(-120*time.Second))
 }
 
 func (n *Node) ChainID() string {


### PR DESCRIPTION
because sometimes nodes are not sync but with `catchingUp: false`